### PR TITLE
Add optional Desc field to set the description in the header.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -54,6 +54,7 @@ type Source struct {
 	mu    sync.Mutex
 	code  string
 	Vm    *goluaez.State
+	Desc  string
 }
 
 // IsNumber indicates that we expect the Source to return a number given the op
@@ -376,7 +377,9 @@ func (s *Source) UpdateHeader(r HeaderUpdater, ends bool, htype string, number s
 			number = "."
 		}
 	}
-	if (s.Op == "first" || s.Op == "self") && htype == ntype {
+	if (s.Desc != "") {
+	   desc = s.Desc
+	} else if (s.Op == "first" || s.Op == "self") && htype == ntype {
 		desc = fmt.Sprintf("transfered from matched variants in %s", s.File)
 	} else if strings.HasSuffix(s.File, ".bam") && s.Field == "" {
 		desc = fmt.Sprintf("calculated by coverage from %s", s.File)

--- a/shared/shared.go
+++ b/shared/shared.go
@@ -25,6 +25,7 @@ type Annotation struct {
 	Columns []int
 	// the names in the output.
 	Names []string
+	Desc string
 }
 
 // Flatten turns an annotation into a slice of Sources. Pass in the index of the file.
@@ -82,7 +83,7 @@ func (a *Annotation) Flatten(index int, basepath string) ([]*Source, error) {
 		if len(a.Names) == 0 {
 			a.Names = a.Fields
 		}
-		sources[i] = &Source{File: a.File, Op: op, Name: a.Names[i], Index: index}
+		sources[i] = &Source{File: a.File, Op: op, Name: a.Names[i], Index: index, Desc: a.Desc}
 		if nil != a.Fields {
 			sources[i].Field = a.Fields[i]
 			sources[i].Column = -1


### PR DESCRIPTION
HI Brent,

This adds a `Desc` field to the annotation configuration so you can override what the description of the field is in the header. Go is new to me so let me know if I screwed anything up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional `Desc` to annotation config and sources, using it to override INFO header descriptions.
> 
> - **API**:
>   - `api.Source`: add `Desc` field and use it in `UpdateHeader` to override auto-generated descriptions.
> - **Shared**:
>   - `shared.Annotation`: add `Desc` field and propagate it in `Flatten` to `Source`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a843cf3af0a9c557ae1ffa77a112b7853a4c8494. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->