### PR TITLE
Make header case-insensitive

### DIFF
--- a/scripts/cadd2vcf.py
+++ b/scripts/cadd2vcf.py
@@ -10,7 +10,7 @@ import toolshed as ts
 def main(precision, path):
     header = None
 
-    tmpl = "{Chrom}\t{Pos}\t.\t{Ref}\t{Alt}\t1\tPASS\traw={RawScore:.%if};phred={PHRED:.%if}" % (precision, precision)
+    tmpl = "{chrom}\t{pos}\t.\t{ref}\t{alt}\t1\tPASS\traw={rawscore:.%if};phred={phred:.%if}" % (precision, precision)
 
     hdr = """\
 ##fileformat=VCFv4.1
@@ -25,11 +25,11 @@ def main(precision, path):
             print(hdr.format(comment=line.strip("# ").strip()))
             continue
         if header is None and line.startswith("#Chrom"):
-            header = line[1:].rstrip().split("\t")
+            header = line[1:].lower().rstrip().split("\t")
             continue
         d = dict(zip(header, line.rstrip().split("\t")))
-        d['PHRED'] = float(d['PHRED'])
-        d['RawScore'] = float(d['RawScore'])
+        d['phred'] = float(d['phred'])
+        d['rawscore'] = float(d['rawscore'])
         print(tmpl.format(**d))
 
 


### PR DESCRIPTION
If you go to the CADD website (http://cadd.gs.washington.edu/) you can submit variants to be scored (useful for novel indels not in their pre-scored database). The score file you get back is in the same TSV format as their database except for the casing of the header line (CHROM instead of Chrom, POS instead of pos, etc.). This change makes it so the script can parse either type of score file.
I'm not sure if you'd want to make this change or not or if there's a better way to do it, but I thought I'd offer it up as a suggestion.