### PR TITLE
Release a binary for Linux ARM64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ all: get build
 
 release:
 	CGO_ENABLED=0 GOARCH=amd64 go build -o vcfanno_linux64 --ldflags '-extldflags "-static"' vcfanno.go
+	CGO_ENABLED=0 GOARCH=arm64 go build -o vcfanno_linux_aarch64 --ldflags '-extldflags "-static"' vcfanno.go
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o vcfanno_osx --ldflags '-extldflags "-static"' vcfanno.go
 
 get:


### PR DESCRIPTION
Hello,

With this PR I' like to request adding a Linux ARM64 release binary!

The Bioconda project is adding support for `linux-aarch64` and we (contributors) will need a binary for [here](https://github.com/bioconda/bioconda-recipes/blob/829a7a0a303b46c03f8eaa79f6176d4cb27791cd/recipes/vcfanno/meta.yaml#L7C1-L11C85)

Thank you!

```
$ uname -a
Linux euler-arm-22 5.10.0-60.74.0.98.oe2203.aarch64 #1 SMP Thu Dec 29 02:26:25 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux

$ file vcfanno_linux_aarch64 
vcfanno_linux_aarch64: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=E62rNTwMz0wrc1wGESg3/q3T06HfpwTrdxN9WGWzt/cE3OQjvQ5RZGUejQsqiT/TSeoMWlySBwJNvlmjc76, with debug_info, not stripped

$ ./vcfanno_linux_aarch64 --help

=============================================
vcfanno version 0.3.5 [built with go1.20.2]

see: https://github.com/brentp/vcfanno
=============================================
Usage of ./vcfanno_linux_aarch64:
  -base-path string
    	optional base-path to prepend to annotation files in the config
  -ends
    	annotate the start and end as well as the interval itself.
  -lua string
    	optional path to a file containing custom lua functions to be used as ops
  -p int
    	number of processes to use. (default 2)
  -permissive-overlap
    	annotate with an overlapping variant even it doesn't share the same ref and alt alleles. Default is to require exact match between variants.
```